### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Swift 2.0 opens a world of opportunity with enhanced Protocols and Protocol Exte
 Too often we find ourselves locked into deep and complicated subclassing trees just to factor out common behavior in our apps. This makes our code  inflexible, hard to navigate, and contain too many dependencies. Using protocols for common features allows us to create default behavior that is additive without complicated subclassing.
 
 ## Setup
-#### Cocoapods (recommended)
+#### CocoaPods (recommended)
 1. Make sure you have downloaded and installed [cocoapods](https://cocoapods.org/).
 2. Add `pod 'STP', '~> 0.3.0'`to your podfile.
 3. Make sure that your podfile includes `use_frameworks!`


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
